### PR TITLE
Remove alert popup

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var bundleAndCache = function(w, path) {
         if (typeof window !== 'undefined') {
           console.warn('Error bundling file: ${path}')
           console.error('${err.message}')
-          alert("BROWSERIFY COMPILE ERROR (check your console for more details): ${err.message}");
         }
       `
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-dev-middleware",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Middleware to compile browserify files on request for development purpose.",
   "keywords": [
     "browserify",


### PR DESCRIPTION
Removes `alert` popup in favor of notification center and bumps version to `1.1.1`. 

@craigspaeth if you get a sec, could you publish to NPM so that I can pull latest into force? 