### PR TITLE
Remove Errorify

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ const bundleAndCache = (w, path) => {
     if (err) {
       console.log(pe.render(new Error(err.message)))
 
+      // Send error to browser console
+      cached[path] = `
+        if (typeof window !== 'undefined') {
+          console.warn('Error bundling file: ${path}')
+          console.error('${err.message}')
+        }
+      `
+
       notifier.notify({
         'title': 'Browserify compile error!',
         'message': 'Check terminal console for more info.'
@@ -27,7 +35,7 @@ const bundleAndCache = (w, path) => {
       w.emit('error')
     } else {
       cached[path] = src.toString()
-      console.log('Bundled: ' + path)
+      console.log('[Bundled] ' + path)
     }
   })
 }
@@ -53,7 +61,6 @@ module.exports = (options) => (req, res, next) => {
           ), watchify.args))
 
           b.add(path)
-          b.plugin(errorify)
 
           const transforms = options.transforms || []
           transforms.forEach((t) => {


### PR DESCRIPTION
Remove `errorify` package for now since it was leading to strange hangs in Force. I also added back in sending errors to the users browser console since that can be useful if you don't notice the beep / notification center alert and are wondering why page wont load! 